### PR TITLE
silence macos zsh default terminal warning

### DIFF
--- a/configs/dot_files/.bashrc
+++ b/configs/dot_files/.bashrc
@@ -11,6 +11,9 @@ esac
 ## default editor
 export EDITOR=vim
 
+## silences the macos zsh default terminal message
+export BASH_SILENCE_DEPRECATION_WARNING=1
+
 GOROOT=$HOME
 
 ################# HISTORY ####################


### PR DESCRIPTION
Adds a env var that will silence the "default interactive shell is now zsh" warning when using bash on macos