### PR TITLE
Fix order of package manager operations

### DIFF
--- a/onboardme/config/onboardme_config.yml
+++ b/onboardme/config/onboardme_config.yml
@@ -60,9 +60,9 @@ package:
     Linux:
       - brew
       - pip3.10
+      - apt
       - snap
       - flatpak
-      - apt
   # list of extra existing packages groups to install
   groups:
     - default

--- a/onboardme/env_config.py
+++ b/onboardme/env_config.py
@@ -4,11 +4,8 @@ import logging as log
 from os import getenv, path, uname
 # rich helps pretty print everything
 from rich.prompt import Confirm
-from rich.logging import RichHandler
 from .console_logging import print_panel
 import yaml
-# this is the only logger that needs to updated manually if you are
-# troubleshooting. set to logging.DEBUG to see errors
 
 
 def load_yaml(yaml_config_file=""):

--- a/onboardme/env_config.py
+++ b/onboardme/env_config.py
@@ -84,7 +84,7 @@ def process_steps(steps=[], firewall=False, browser=False):
     return result_steps
 
 
-def fix_pkg_mngr_order(package_managers_list=[]):
+def sort_pkgmngrs(package_managers_list=[]):
     """
     make sure the package managers are in the right order 🤦
     """
@@ -156,7 +156,7 @@ def process_configs(overwrite=False, repo="", git_branch="", pkg_mngrs=[],
     valid_steps = process_steps(final_defaults['steps'][OS[0]],
                                 final_defaults['remote_hosts'])
     final_defaults['steps'][OS[0]] = valid_steps
-    valid_pkg_mngrs = fix_pkg_mngr_order(final_defaults['package']['managers'])
-    final_defaults['package']['managers'] = valid_pkg_mngrs
+    sorted_mngrs = sort_pkgmngrs(final_defaults['package']['managers'][OS[0]])
+    final_defaults['package']['managers'][OS[0]] = sorted_mngrs
 
     return final_defaults

--- a/onboardme/env_config.py
+++ b/onboardme/env_config.py
@@ -84,6 +84,19 @@ def process_steps(steps=[], firewall=False, browser=False):
     return result_steps
 
 
+def fix_pkg_mngr_order(package_managers_list=[]):
+    """
+    make sure the package managers are in the right order 🤦
+    """
+    final_list = []
+    package_managers = ['brew', 'pip3.10', 'apt', 'snap', 'flatpak']
+    for mngr in package_managers:
+        if mngr in package_managers_list:
+            final_list.append(mngr)
+
+    return final_list
+
+
 def fill_in_defaults(defaults={}, user_config={}, always_prefer_default=False):
     """
     Compares/Combines a default dict and another dict. Prefer default values
@@ -143,5 +156,7 @@ def process_configs(overwrite=False, repo="", git_branch="", pkg_mngrs=[],
     valid_steps = process_steps(final_defaults['steps'][OS[0]],
                                 final_defaults['remote_hosts'])
     final_defaults['steps'][OS[0]] = valid_steps
+    valid_pkg_mngrs = fix_pkg_mngr_order(final_defaults['package']['managers'])
+    final_defaults['package']['managers'] = valid_pkg_mngrs
 
     return final_defaults

--- a/onboardme/ide_setup.py
+++ b/onboardme/ide_setup.py
@@ -29,7 +29,7 @@ def vim_setup():
 
     # trick to not run youcompleteme init every single time
     init_ycm = False
-    ycm_dir = os.path.join(HOME_DIR, '.vim/plugged/YouCompleteMe/install.sh')
+    ycm_dir = path.join(HOME_DIR, '.vim/plugged/YouCompleteMe/install.sh')
     if not path.exists(ycm_dir):
         init_ycm = True
 

--- a/onboardme/ide_setup.py
+++ b/onboardme/ide_setup.py
@@ -6,6 +6,7 @@ AUTHOR:  Jesse Hitch
 LICENSE: GNU AFFERO GENERAL PUBLIC LICENSE
 """
 
+import logging as log
 from git import Repo, RemoteProgress
 from os import path
 from pathlib import Path

--- a/onboardme/ide_setup.py
+++ b/onboardme/ide_setup.py
@@ -29,7 +29,8 @@ def vim_setup():
 
     # trick to not run youcompleteme init every single time
     init_ycm = False
-    if not path.exists(f'{HOME_DIR}/.vim/plugged/YouCompleteMe/install.py'):
+    ycm_dir = os.path.join(HOME_DIR, '.vim/plugged/YouCompleteMe/install.sh')
+    if not path.exists(ycm_dir):
         init_ycm = True
 
     # this is for installing vim-plug
@@ -49,7 +50,7 @@ def vim_setup():
 
     if init_ycm:
         # This is for you complete me, which is a python completion module
-        subproc(f'{HOME_DIR}/.vim/plugged/YouCompleteMe/install.py')
+        subproc(ycm_dir)
 
     return True
 

--- a/onboardme/pkg_management.py
+++ b/onboardme/pkg_management.py
@@ -58,17 +58,15 @@ def run_pkg_mngrs(pkg_mngrs=[], pkg_groups=[]):
     list passed in, only use brew/pip3.10 for mac. Takes optional variable,
     pkg_group_lists to install optional packages.
     """
-    log.debug(f"pkg_mngrs: {pkg_mngrs}", extra={"markup": True})
-    # brew has a special flow with brew files
-    if 'brew' in pkg_mngrs:
-        brew_install_upgrade(OS[0], pkg_groups)
-        if type(pkg_mngrs) is list or type(pkg_mngrs) is set:
-            pkg_mngrs.remove('brew')
-
     pkg_mngrs_list_of_dicts = load_yaml(path.join(PWD, 'config/packages.yml'))
+    log.debug(f"pkg_mngrs: {pkg_mngrs}", extra={"markup": True})
 
     # we iterate through pkg_mngrs which should already be sorted
     for pkg_mngr in pkg_mngrs:
+        # brew has a special flow with "Brewfile"s
+        if 'brew' in pkg_mngrs:
+            brew_install_upgrade(OS[0], pkg_groups)
+            continue
         pkg_mngr_dict = pkg_mngrs_list_of_dicts[pkg_mngr]
         pkg_emoji = pkg_mngr_dict['emoji']
         msg = f'{pkg_emoji} [green][b]{pkg_mngr}[/b][/] app Installs'

--- a/onboardme/pkg_management.py
+++ b/onboardme/pkg_management.py
@@ -60,13 +60,18 @@ def run_pkg_mngrs(pkg_mngrs=[], pkg_groups=[]):
     # brew has a special flow with brew files
     if 'brew' in pkg_mngrs:
         brew_install_upgrade(OS[0], pkg_groups)
-        pkg_mngrs.remove('brew')
+        if type(pkg_mngr) is list or type(pkg_mngr) is set:
+            pkg_mngrs.remove('brew')
 
-    pkg_mngrs_list = load_yaml(f'{PWD}/config/packages.yml')
+    pkg_mngrs_list_of_dicts = load_yaml(f'{PWD}/config/packages.yml')
+
+    # Rearrange list by other list order Using list comprehension
+    default_order = ['pip3.10', 'apt', 'snap', 'flatpak']
+    pkg_mngrs = set([ele for ele in default_order if ele in pkg_mngr])
 
     # just in case we got any duplicates, we iterate through pkg_mngrs as a set
     for pkg_mngr in set(pkg_mngrs):
-        pkg_mngr_dict = pkg_mngrs_list[pkg_mngr]
+        pkg_mngr_dict = pkg_mngrs_list_of_dicts[pkg_mngr]
         pkg_emoji = pkg_mngr_dict['emoji']
         msg = f'{pkg_emoji} [green][b]{pkg_mngr}[/b][/] app Installs'
         print_header(msg)

--- a/onboardme/pkg_management.py
+++ b/onboardme/pkg_management.py
@@ -67,8 +67,8 @@ def run_pkg_mngrs(pkg_mngrs=[], pkg_groups=[]):
 
     pkg_mngrs_list_of_dicts = load_yaml(path.join(PWD, 'config/packages.yml'))
 
-    # just in case we got any duplicates, we iterate through pkg_mngrs as a set
-    for pkg_mngr in set(pkg_mngrs):
+    # we iterate through pkg_mngrs which should already be sorted
+    for pkg_mngr in pkg_mngrs:
         pkg_mngr_dict = pkg_mngrs_list_of_dicts[pkg_mngr]
         pkg_emoji = pkg_mngr_dict['emoji']
         msg = f'{pkg_emoji} [green][b]{pkg_mngr}[/b][/] app Installs'

--- a/onboardme/pkg_management.py
+++ b/onboardme/pkg_management.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3.10
+import logging as log
 from os import path
 
 # custom libs
@@ -57,20 +58,17 @@ def run_pkg_mngrs(pkg_mngrs=[], pkg_groups=[]):
     list passed in, only use brew/pip3.10 for mac. Takes optional variable,
     pkg_group_lists to install optional packages.
     """
+    log.debug(f"pkg_mngrs: {pkg_mngrs}", extra={"markup": True})
     # brew has a special flow with brew files
     if 'brew' in pkg_mngrs:
         brew_install_upgrade(OS[0], pkg_groups)
         if type(pkg_mngrs) is list or type(pkg_mngrs) is set:
             pkg_mngrs.remove('brew')
 
-    pkg_mngrs_list_of_dicts = load_yaml(f'{PWD}/config/packages.yml')
-
-    # Rearrange list by other list order Using list comprehension
-    default_order = ['pip3.10', 'apt', 'snap', 'flatpak']
-    pkg_mngrs_list = set([ele for ele in default_order if ele in pkg_mngrs])
+    pkg_mngrs_list_of_dicts = load_yaml(path.join(PWD, 'config/packages.yml'))
 
     # just in case we got any duplicates, we iterate through pkg_mngrs as a set
-    for pkg_mngr in set(pkg_mngrs_list):
+    for pkg_mngr in set(pkg_mngrs):
         pkg_mngr_dict = pkg_mngrs_list_of_dicts[pkg_mngr]
         pkg_emoji = pkg_mngr_dict['emoji']
         msg = f'{pkg_emoji} [green][b]{pkg_mngr}[/b][/] app Installs'

--- a/onboardme/pkg_management.py
+++ b/onboardme/pkg_management.py
@@ -60,17 +60,17 @@ def run_pkg_mngrs(pkg_mngrs=[], pkg_groups=[]):
     # brew has a special flow with brew files
     if 'brew' in pkg_mngrs:
         brew_install_upgrade(OS[0], pkg_groups)
-        if type(pkg_mngr) is list or type(pkg_mngr) is set:
+        if type(pkg_mngrs) is list or type(pkg_mngrs) is set:
             pkg_mngrs.remove('brew')
 
     pkg_mngrs_list_of_dicts = load_yaml(f'{PWD}/config/packages.yml')
 
     # Rearrange list by other list order Using list comprehension
     default_order = ['pip3.10', 'apt', 'snap', 'flatpak']
-    pkg_mngrs = set([ele for ele in default_order if ele in pkg_mngr])
+    pkg_mngrs_list = set([ele for ele in default_order if ele in pkg_mngrs])
 
     # just in case we got any duplicates, we iterate through pkg_mngrs as a set
-    for pkg_mngr in set(pkg_mngrs):
+    for pkg_mngr in set(pkg_mngrs_list):
         pkg_mngr_dict = pkg_mngrs_list_of_dicts[pkg_mngr]
         pkg_emoji = pkg_mngr_dict['emoji']
         msg = f'{pkg_emoji} [green][b]{pkg_mngr}[/b][/] app Installs'
@@ -80,7 +80,7 @@ def run_pkg_mngrs(pkg_mngrs=[], pkg_groups=[]):
         pkg_cmds = pkg_mngr_dict['commands']
         for pre_cmd in ['setup', 'update', 'upgrade']:
             if pre_cmd in pkg_cmds:
-                subproc([pkg_cmds[pre_cmd]], spinner=False) 
+                subproc([pkg_cmds[pre_cmd]], spinner=False)
 
         # list of actually installed packages
         installed_pkgs = subproc([pkg_cmds['list']], quiet=True)

--- a/onboardme/pkg_management.py
+++ b/onboardme/pkg_management.py
@@ -64,7 +64,7 @@ def run_pkg_mngrs(pkg_mngrs=[], pkg_groups=[]):
     # we iterate through pkg_mngrs which should already be sorted
     for pkg_mngr in pkg_mngrs:
         # brew has a special flow with "Brewfile"s
-        if 'brew' in pkg_mngrs:
+        if pkg_mngr == 'brew':
             brew_install_upgrade(OS[0], pkg_groups)
             continue
         pkg_mngr_dict = pkg_mngrs_list_of_dicts[pkg_mngr]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='onboardme',
                    lic_class],
       python_requires='>3.10',
       keywords='onboardme, onboarding, desktop-setup, setuptools, development',
-      version='0.14.3',
+      version='0.14.4',
       project_urls={
           'Documentation': 'https://jessebot.github.io/onboardme/onboardme',
           'Source': 'http://github.com/jessebot/onboardme',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='onboardme',
                    lic_class],
       python_requires='>3.10',
       keywords='onboardme, onboarding, desktop-setup, setuptools, development',
-      version='0.14.6',
+      version='0.14.7',
       project_urls={
           'Documentation': 'https://jessebot.github.io/onboardme/onboardme',
           'Source': 'http://github.com/jessebot/onboardme',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='onboardme',
                    lic_class],
       python_requires='>3.10',
       keywords='onboardme, onboarding, desktop-setup, setuptools, development',
-      version='0.14.4',
+      version='0.14.5',
       project_urls={
           'Documentation': 'https://jessebot.github.io/onboardme/onboardme',
           'Source': 'http://github.com/jessebot/onboardme',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='onboardme',
                    lic_class],
       python_requires='>3.10',
       keywords='onboardme, onboarding, desktop-setup, setuptools, development',
-      version='0.14.0',
+      version='0.14.1',
       project_urls={
           'Documentation': 'https://jessebot.github.io/onboardme/onboardme',
           'Source': 'http://github.com/jessebot/onboardme',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='onboardme',
                    lic_class],
       python_requires='>3.10',
       keywords='onboardme, onboarding, desktop-setup, setuptools, development',
-      version='0.14.2',
+      version='0.14.3',
       project_urls={
           'Documentation': 'https://jessebot.github.io/onboardme/onboardme',
           'Source': 'http://github.com/jessebot/onboardme',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='onboardme',
                    lic_class],
       python_requires='>3.10',
       keywords='onboardme, onboarding, desktop-setup, setuptools, development',
-      version='0.14.5',
+      version='0.14.6',
       project_urls={
           'Documentation': 'https://jessebot.github.io/onboardme/onboardme',
           'Source': 'http://github.com/jessebot/onboardme',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='onboardme',
                    lic_class],
       python_requires='>3.10',
       keywords='onboardme, onboarding, desktop-setup, setuptools, development',
-      version='0.14.7',
+      version='0.14.8',
       project_urls={
           'Documentation': 'https://jessebot.github.io/onboardme/onboardme',
           'Source': 'http://github.com/jessebot/onboardme',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='onboardme',
                    lic_class],
       python_requires='>3.10',
       keywords='onboardme, onboarding, desktop-setup, setuptools, development',
-      version='0.13.12',
+      version='0.14.0',
       project_urls={
           'Documentation': 'https://jessebot.github.io/onboardme/onboardme',
           'Source': 'http://github.com/jessebot/onboardme',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='onboardme',
                    lic_class],
       python_requires='>3.10',
       keywords='onboardme, onboarding, desktop-setup, setuptools, development',
-      version='0.14.1',
+      version='0.14.2',
       project_urls={
           'Documentation': 'https://jessebot.github.io/onboardme/onboardme',
           'Source': 'http://github.com/jessebot/onboardme',


### PR DESCRIPTION
package managers were not installed in any particular order, but if we don't install apt packages first on Linux, it breaks, because then apt has to install snap, and when it gets to snap, snap will fail, because snap wasn't installed.

yo, I hate package managers. There's too many.