### PR TITLE
git config --global push.autoSetupRemote = true

### DIFF
--- a/onboardme/dot_files.py
+++ b/onboardme/dot_files.py
@@ -26,8 +26,9 @@ def setup_dot_files(OS='Linux', overwrite=False,
     chdir(git_dir)
     opts = {'quiet': True, 'cwd': git_dir}
 
-    # global command: use main instead of master as default branch
+    # global: use main as default branch, always push up new remote branch
     cmds = ['git config --global init.defaultBranch main',
+            'git config --global push.autoSetupRemote true',
             f'git --git-dir={git_dir} --work-tree={HOME_DIR} init',
             'git config status.showUntrackedFiles no']
     subproc(cmds, spinner=False, **opts)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='onboardme',
                    lic_class],
       python_requires='>3.10',
       keywords='onboardme, onboarding, desktop-setup, setuptools, development',
-      version='0.14.14',
+      version='0.14.15',
       project_urls={
           'Documentation': 'https://jessebot.github.io/onboardme/onboardme',
           'Source': 'http://github.com/jessebot/onboardme',


### PR DESCRIPTION
If the remote branch doesn't exist, create it by default, for all repos.

Just adding this in as I still don't have my `~/.gitconfig` in my dot files, because my current git config has my personal info like:

```ini
[init]
	defaultBranch = main
[user]
	name = Jesse Bot
        email = myrealemail@coolwebsite4dogs.com
[push]
	autoSetupRemote = true
```

And this is kind of a stop gap to set this up without having personal info in my dot files that cloned for onboardme. This is kind of hacky, and what I should do is allow the user to configure git as a module like everything else, but that's a ticket for another time.