### PR TITLE
85 automate getting version number and add checks for yaml

### DIFF
--- a/onboardme/__init__.py
+++ b/onboardme/__init__.py
@@ -1,12 +1,16 @@
 """
-    NAME:           Onboardme
+    NAME:           onboardme
     DESCRIPTION:    Program to take care of a bunch of onboarding tasks for new
-                    machines running macOS and/or Debian.
+                    machines running macOS and/or Debian, including:
+                      dot_files, packages, ide_setup, and group management
     AUTHOR:         Jesse Hitch
     LICENSE:        GNU AFFERO GENERAL PUBLIC LICENSE
 """
 from click import option, command, Choice
-import importlib
+# for importing modules by str names
+from importlib import import_module
+# for getting the version of onboardme
+from importlib.metadata import version
 import logging
 
 # rich helps pretty print everything
@@ -15,8 +19,7 @@ from rich.logging import RichHandler
 
 # custom libs
 from .help_text import RichCommand, options_help
-from .env_config import check_os_support, OS, process_configs, \
-                        USR_CONFIG_FILE, get_version
+from .env_config import check_os_support, OS, process_configs, USR_CONFIG_FILE
 from .env_config import DEFAULTS as OPTS
 from .console_logging import print_manual_steps
 
@@ -100,9 +103,12 @@ def main(log_level: str = "",
     flatpak, and snap packages. On mac, it only installs brew/pip3.11 packages.
     config loading tries to load: cli options and then .config/onboardme/*
     """
-    # return the version if that's all they want
+
+    # only return the version if --version was passed in
     if version:
-        return get_version()
+        print(f'\n🎉 v{version("onboardme")}\n')
+        return True
+
     # before we do anything, we need to make sure this OS is supported
     check_os_support()
 
@@ -133,8 +139,8 @@ def main(log_level: str = "",
             run_pkg_mngrs(pkg_mngrs, pkg_groups)
 
         elif step in ['vim_setup', 'neovim_setup', 'font_setup']:
-            # import step from ide_setup.py in same directory
-            importlib.import_module('onboardme.ide_setup', package=f'.{step}')
+            # import step's function from ide_setup.py in same directory
+            import_module('onboardme.ide_setup', package=f'.{step}')
             func = getattr(ide_setup, step)
             func()
 

--- a/onboardme/__init__.py
+++ b/onboardme/__init__.py
@@ -10,7 +10,7 @@ from click import option, command, Choice
 # for importing modules by str names
 from importlib import import_module
 # for getting the version of onboardme
-from importlib.metadata import version
+from importlib.metadata import version as get_version
 import logging
 
 # rich helps pretty print everything
@@ -106,7 +106,7 @@ def main(log_level: str = "",
 
     # only return the version if --version was passed in
     if version:
-        print(f'\n🎉 v{version("onboardme")}\n')
+        print(f'\n🎉 v{get_version("onboardme")}\n')
         return True
 
     # before we do anything, we need to make sure this OS is supported

--- a/onboardme/env_config.py
+++ b/onboardme/env_config.py
@@ -7,15 +7,25 @@ from os import getenv, path, uname
 from rich.prompt import Confirm
 from .console_logging import print_panel
 import yaml
+# toml lib in Python 3.11
+import tomli
 
 
-def load_yaml(yaml_config_file=""):
+def load_cfg(config_file=""):
     """
-    load config yaml files for onboardme and return as dicts
+    load yaml or toml config files for onboardme.
+    return dict
     """
-    if path.exists(yaml_config_file):
-        with open(yaml_config_file, 'r') as yaml_file:
-            return yaml.safe_load(yaml_file)
+    if path.exists(config_file):
+        # yaml response
+        if config_file.endswith(("yaml", "yml"):
+            with open(config_file, 'r') as yaml_file:
+                return yaml.safe_load(yaml_file)
+
+        # toml has a seperate library to use
+        if config_file.endswith("toml"):
+            with open(config_file, 'rb') as toml_file:
+                return tomli.load(toml_file)
     else:
         # print(f"Config file we got was not present: {yaml_config_file}")
         return None
@@ -26,8 +36,8 @@ PWD = path.dirname(__file__)
 HOME_DIR = getenv("HOME")
 
 # defaults
-DEFAULTS = load_yaml(f"{PWD}/config/onboardme_config.yml")
-USR_CONFIG_FILE = load_yaml(f'{HOME_DIR}/.config/onboardme/config.yaml')
+DEFAULTS = load_cfg(f"{PWD}/config/onboardme_config.yml")
+USR_CONFIG_FILE = load_cfg(f'{HOME_DIR}/.config/onboardme/config.yaml')
 
 # env
 SYSINFO = uname()

--- a/onboardme/env_config.py
+++ b/onboardme/env_config.py
@@ -51,7 +51,8 @@ def get_version():
     """
     # this is hardcoded because we're about upgrade major versions & grab
     # pyproject.toml version info with python3.11
-    print("\n🎉 v0.15.2\n")
+    version = load_cfg("pyproject.toml")['tool.poetry']['version']
+    print(f"\n🎉 v{version}\n")
     return True
 
 

--- a/onboardme/env_config.py
+++ b/onboardme/env_config.py
@@ -2,30 +2,27 @@
 environment variable loading library for onboardme
 """
 import logging as log
+# for system data, environment data, and checking/joining paths
 from os import getenv, path, uname
 # rich helps pretty print everything
 from rich.prompt import Confirm
-from .console_logging import print_panel
 import yaml
-# toml lib in Python 3.11
-import tomli
+
+# custom libs
+from .console_logging import print_panel
 
 
 def load_cfg(config_file=""):
     """
-    load yaml or toml config files for onboardme.
+    load yaml config files for onboardme.
     return dict
     """
+    # make sure the path is valid
     if path.exists(config_file):
-        # yaml response
-        if config_file.endswith(("yaml", "yml"):
+        # make sure it's a yaml file extension
+        if config_file.endswith((".yaml", ".yml")):
             with open(config_file, 'r') as yaml_file:
                 return yaml.safe_load(yaml_file)
-
-        # toml has a seperate library to use
-        if config_file.endswith("toml"):
-            with open(config_file, 'rb') as toml_file:
-                return tomli.load(toml_file)
     else:
         # print(f"Config file we got was not present: {yaml_config_file}")
         return None
@@ -43,17 +40,6 @@ USR_CONFIG_FILE = load_cfg(f'{HOME_DIR}/.config/onboardme/config.yaml')
 SYSINFO = uname()
 # this will be something like ('Darwin', 'x86_64')
 OS = (SYSINFO.sysname, SYSINFO.machine)
-
-
-def get_version():
-    """
-    get the version of onboardme, print it, and return True
-    """
-    # this is hardcoded because we're about upgrade major versions & grab
-    # pyproject.toml version info with python3.11
-    version = load_cfg("pyproject.toml")['tool.poetry']['version']
-    print(f"\n🎉 v{version}\n")
-    return True
 
 
 def check_os_support():
@@ -110,14 +96,20 @@ def process_steps(steps=[], firewall=False, browser=False):
 def sort_pkgmngrs(package_managers_list=[]):
     """
     make sure the package managers are in the right order 🤦
+    e.g. apt installs snap and flatpak, so niether can be run until apt is run
+
+    Takes list of package manager str and reorders them be (if they exist):
+       ['brew', 'pip3.11', 'apt', 'snap', 'flatpak']
+    Returns reordered_list
     """
-    final_list = []
+    reordered_list = []
     package_managers = ['brew', 'pip3.11', 'apt', 'snap', 'flatpak']
+
     for mngr in package_managers:
         if mngr in package_managers_list:
-            final_list.append(mngr)
+            reordered_list.append(mngr)
 
-    return final_list
+    return reordered_list
 
 
 def fill_in_defaults(defaults={}, user_config={}, always_prefer_default=False):

--- a/onboardme/pkg_management.py
+++ b/onboardme/pkg_management.py
@@ -2,7 +2,7 @@ import logging as log
 from os import path
 
 # custom libs
-from .env_config import OS, PWD, HOME_DIR, load_yaml
+from .env_config import OS, PWD, HOME_DIR, load_cfg
 from .console_logging import print_header
 from .console_logging import print_sub_header as sub_header
 from .subproc import subproc
@@ -19,10 +19,10 @@ def run_pkg_mngrs(pkg_mngrs=[], pkg_groups=[]):
     # check to make sure the user didn't pass in their own packages.yml
     user_packages = path.join(HOME_DIR, '.config/onboardme/packages.yml')
     if path.exists(user_packages):
-        pkg_mngrs_list_of_dicts = load_yaml(user_packages)
+        pkg_mngrs_list_of_dicts = load_cfg(user_packages)
     else:
         default_config = path.join(PWD, 'config/packages.yml')
-        pkg_mngrs_list_of_dicts = load_yaml(default_config)
+        pkg_mngrs_list_of_dicts = load_cfg(default_config)
 
     log.debug(f"pkg_mngrs: {pkg_mngrs}", extra={"markup": True})
     log.debug(f"pkg_groups: {pkg_groups}", extra={"markup": True})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "onboardme"
-version       = "0.15.2"
+version       = "0.15.3"
 description   = "An onboarding tool to install dot files and packages including a default mode with sensible defaults to run on most Debian/macOS machines."
 authors       = ["Jesse Hitch <jessebot@linux.com>"]
 license       = "AGPL-3.0-or-later"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-from setuptools import setup
-
-
-setup(name='onboardme')


### PR DESCRIPTION
was going to process pyproject.toml for `onboardme --version`, but then realized you could use `importlib.metadata.version`, however, I kept some of the refactor after ripping out the toml stuff.