### PR TITLE
98 snap command not available after installation via apt on debian

### DIFF
--- a/onboardme/config/packages.yml
+++ b/onboardme/config/packages.yml
@@ -218,11 +218,10 @@ snap:
     list: "snap list"
     install: "sudo snap install "
   packages:
-    default:
+    gui:
       - core
       # screen debugger/sharing tool for android
       - scrcpy
-    gui:
       # rss feed reader
       - fluent-reader
       # media player

--- a/onboardme/pkg_management.py
+++ b/onboardme/pkg_management.py
@@ -73,8 +73,15 @@ def run_pkg_mngrs(pkg_mngrs=[], pkg_groups=[]):
             # commands for listing, installing, updating, upgrading, & cleanup
             pkg_cmds = pkg_mngr_dict['commands']
 
-            # run package manager specific setup if needed e.g. update/upgrade
-            run_preinstall_cmds(pkg_cmds, pkg_groups)
+            if pkg_mngr == 'snap' and not shutil.which('snap'):
+                # ref: https://snapcraft.io/docs/installing-snap-on-debian
+                log.warn("snap is either not installed, or you need to log out"
+                         "and back in (or reboot) for it to be available.")
+                # continues onto the next package manager
+                continue
+            else:
+                # run package manager specific setup if needed: update/upgrade
+                run_preinstall_cmds(pkg_cmds, pkg_groups)
 
             # run the list command for the given package manager
             list_pkgs = subproc([pkg_cmds['list']], quiet=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "onboardme"
-version       = "0.15.7"
+version       = "0.15.8_a"
 description   = "An onboarding tool to install dot files and packages including a default mode with sensible defaults to run on most Debian/macOS machines."
 authors       = ["Jesse Hitch <jessebot@linux.com>"]
 license       = "AGPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "onboardme"
-version       = "0.15.8_a"
+version       = "0.15.8"
 description   = "An onboarding tool to install dot files and packages including a default mode with sensible defaults to run on most Debian/macOS machines."
 authors       = ["Jesse Hitch <jessebot@linux.com>"]
 license       = "AGPL-3.0-or-later"
@@ -27,6 +27,12 @@ rich      = "^12.6.0"
 PyYAML    = "^6.0"
 GitPython = "^3.1.29"
 wget      = "^3.2"
+
+[[tool.poetry.source]]
+name = "testpypi"
+url = "https://test.pypi.org/simple/"
+default = false
+secondary = false
 
 [tools.poetry.plugins."onboardme.application.plugin"]
 "onboardme" = "onboardme:main"


### PR DESCRIPTION
This should make sure that if the snap command is not available, we print out a log message letting the user know it's expected, and then we don't fail out of the script, so we can then keep going with flatpak, etc.