### PR TITLE
Fix empty continuation warning

### DIFF
--- a/Dockerfile.brew
+++ b/Dockerfile.brew
@@ -37,5 +37,5 @@ RUN apt-get update && \
   wget https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh && \
   chmod +x install.sh && \
   chmod 777 install.sh && \
-  /bin/bash install.sh && git config --global init.defaultBranch main \
+  /bin/bash install.sh && git config --global init.defaultBranch main
 


### PR DESCRIPTION
```bash
[WARNING]: Empty continuation line found in:
    RUN apt-get update &&   apt-get upgrade -y &&   useradd -ms /bin/bash onboardme &&   apt-get install -y   python3-pip   python3-dev   python3-venv   build-essential   sudo   wget   curl   git   vim &&   apt-get install -y twine &&   wget https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh &&   chmod +x install.sh &&   chmod 777 install.sh &&   /bin/bash install.sh && git config --global init.defaultBranch main
[WARNING]: Empty continuation lines will become errors in a future release.
```