### PR TITLE
Add import shutil

### DIFF
--- a/onboardme/pkg_management.py
+++ b/onboardme/pkg_management.py
@@ -1,4 +1,5 @@
 import logging as log
+import shutil
 from os import path
 
 from .env_config import OS, PWD, HOME_DIR, load_cfg


### PR DESCRIPTION
Adds import shutil at the top of the script to prevent line 77 from causing an error when installing the -g gaming package


line 77:
```python
if pkg_mngr == 'snap' and not shutil.which('snap'):
```