### PR TITLE
fixing AttributeError: NoneType object has no attribute 'split'

### DIFF
--- a/onboardme/pkg_management.py
+++ b/onboardme/pkg_management.py
@@ -98,8 +98,11 @@ def run_pkg_mngrs(pkg_mngrs=[], pkg_groups=[]):
 
             list_pkgs = subproc([list_cmd], quiet=True)
 
-            # create list of installed packages to iterate on
-            installed_pkgs = list_pkgs.split()
+            if list_pkgs:
+                # create list of installed packages to iterate on
+                installed_pkgs = list_pkgs.split()
+            else:
+                installed_pkgs = []
 
             # iterate through package groups for a given package manager
             for pkg_group in pkg_groups:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "onboardme"
-version       = "0.15.12"
+version       = "0.15.13"
 description   = "An onboarding tool to install dot files and packages including a default mode with sensible defaults to run on most computers running Debian based distros or macOS."
 authors       = ["Jesse Hitch <jessebot@linux.com>"]
 license       = "AGPL-3.0-or-later"


### PR DESCRIPTION
flatpak fails to run on initial install where packages are still not installed and it tries to list them