### PR TITLE
Transition to usage of pipx to comply with PEP668

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -134,24 +134,29 @@ echo -e "--------------------------\033[94m Checking for Python3 and pip3\033[00
 # check to make sure we have python3 and pip3 installed
 which python3.11 > /dev/null
 py_return_code=$?
+
 if [ $py_return_code -ne 0 ]; then
-    echo "Installing Python3.11..."
     if [ "$OS" == "Darwin" ]; then
+	echo "Installing Python3.11 via brew..."
         brew install python@3.11
+    	echo -e "\033[92mPython3.11 installed :3 \033[00m"
     else
-        os_version=$(grep VERSION_CODENAME /etc/os-release | awk -F '=' '{print $2}')
-        if [ $os_version == "bookworm" ]; then
-            sudo apt install python3 python3-dev python3-pip
-        else
-            sudo apt install software-properties-common -y
-            sudo add-apt-repository ppa:deadsnakes/ppa
-            sudo apt install python3.11
-            curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
-        fi
+	echo "Installing Python3.11 via apt..."
+        sudo apt install software-properties-common -y
+        sudo add-apt-repository ppa:deadsnakes/ppa
+        sudo apt install python3.11
+        curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
+	echo -e "\033[92mPython3.11 installed :3 \033[00m"
     fi
-    echo -e "\033[92mPython3.11 installed :3 \033[00m"
 else
     echo -e "\033[92mPython3.11 already installed :3 \033[00m"
+    which pip3.11 > /dev/null
+    pip_return_code=$?
+    if [ $pip_return_code -ne 0 ]; then
+        echo -e "\033[92mInstalling pip via apt... \033[00m"
+        sudo apt-get update && apt-get install -y python3-pip
+        echo -e "\033[92mPip3.11 installed :3 \033[00m"
+    fi
 fi
 
 echo -e "--------------------------\033[94m Installing OnBoardMe :D \033[00m -------------------------"

--- a/setup.sh
+++ b/setup.sh
@@ -36,7 +36,7 @@ echo -e "\n-------------------------------- \033[94m 🎬 Beginning Setup \033[0
 echo ""
 if [[ "$OS" == *"Linux"* ]]; then
     echo -e "---------------------------- \033[94m Updating existing apt packages \033[00m --------------------"
-    sudo apt update && sudo apt upgrade
+    DEBIAN_FRONTEND=noninteractive sudo apt-get update; sudo apt-get -y upgrade
     echo -e "\033[92m apt updated/upgraded :3 \033[00m"
 fi
 
@@ -138,7 +138,8 @@ py_return_code=$?
 if [ $py_return_code -ne 0 ]; then
     if [ "$OS" == "Darwin" ]; then
 	echo "Installing Python3.11 via brew..."
-        brew install python@3.11
+        brew install python@3.11 pipx
+	pipx ensurepath
     	echo -e "\033[92mPython3.11 installed :3 \033[00m"
     else
 	echo "Installing Python3.11 via apt..."
@@ -154,14 +155,15 @@ else
     pip_return_code=$?
     if [ $pip_return_code -ne 0 ]; then
         echo -e "\033[92mInstalling pip via apt... \033[00m"
-        sudo apt-get update && apt-get install -y python3-pip
-        echo -e "\033[92mPip3.11 installed :3 \033[00m"
+        sudo apt-get update && sudo apt-get install -y python3-pip pipx python3-venv
+        pipx ensurepath
+	echo -e "\033[92mPip3.11 installed :3 \033[00m"
     fi
 fi
 
 echo -e "--------------------------\033[94m Installing OnBoardMe :D \033[00m -------------------------"
 
-pip3.11 install onboardme
+pipx install onboardme
 pip_install_return_code=$?
 
 if [ $pip_install_return_code -ne 0 ]; then


### PR DESCRIPTION
Hoi Jessebot 👋 

Thanks again for maintaining this project - it's been great being able to provide a consistent development environment across my team's remote servers and headless devices that doesn't rely on VScode. 💻 🧑‍🔬 💯 

## Whats the problem?

This PR resolves https://github.com/jessebot/onboardme/issues/155

In the latest version of Debian12, a new requirement for running pip inside of a virtual environment is being enforced
in order to comply with [PEP668](https://peps.python.org/pep-0668/)

After you have installed pip, if you attempt to install a package that is not bundled by Debian, you will receive this very strongly worded message:

```bash
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
```

## How is it fixed?

For apt:
- I added the installation of pipx and python3-venv 
- added `pipx ensurepath` after the install to add the correct $PATH values

For brew:
- only added pipx as python3-venv is included int eh brew python3 install already
- Also added `pipx ensurepath` after the install to add the correct $PATH values

Finally, I changed the install method for `onboardme` to use `pipx` instead of `pip3.11`

## Final Notes

Because this all happens in-line, you will still receive the following warning stating that the $PATH has not been updated, which will disappear once the user sources their ~/.bashrc file. You already tell them to do that so I don't think this is a functional issue and the output could probably be silenced without consequence 

```bash
  installed package onboardme 0.18.2, installed using Python 3.11.2
  These apps are now globally available
    - onboardme
⚠️  Note: '/home/friend/.local/bin' is not on your PATH environment variable. These apps will not be globally accessible until your PATH is updated. Run `pipx ensurepath` to
    automatically add it, or manually modify your PATH in your shell's config file (i.e. ~/.bashrc)
```