### PR TITLE
Add conditional check for OS version before running brew tap

### DIFF
--- a/onboardme/pkg_management.py
+++ b/onboardme/pkg_management.py
@@ -97,7 +97,7 @@ def run_pkg_mngrs(pkg_mngrs: list, pkg_groups=[]) -> None:
 
         available_pkg_groups = pkg_mngr_dict['packages']
         log.debug(f"pkg groups for {pkg_mngr} are {available_pkg_groups}")
-
+        
         # brew has a special flow because it works on both linux and mac
         if pkg_mngr == 'brew':
             if 'Darwin' in OS:
@@ -124,8 +124,9 @@ def run_pkg_mngrs(pkg_mngrs: list, pkg_groups=[]) -> None:
                 continue
 
             if pkg_mngr == 'brew':
-                # this installs macOS brew taps
-                install_brew_taps(pkg_mngr_dict['taps']['macOS'])
+                if 'Darwin' in OS:
+                    # this installs macOS brew taps
+                    install_brew_taps(pkg_mngr_dict['taps']['macOS'])
 
             # run package manager specific setup if needed: update/upgrade
             run_preinstall_cmds(pkg_cmds, pkg_groups)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "onboardme"
-version       = "0.18.4"
+version       = "0.18.5"
 description   = "Install dot files and packages, including a base mode with sensible defaults to run on most computers running Debian based distros or macOS."
 authors       = ["Jesse Hitch <jessebot@linux.com>"]
 license       = "AGPL-3.0-or-later"


### PR DESCRIPTION
Hoi! 👋 

This PR aims to resolve https://github.com/jessebot/onboardme/issues/168

This error was caused by `pkg_management.py` assuming that MacOS will be the OS when `brew` is present:

```python
if pkg_mngr == 'brew':
    # this installs macOS brew taps
    install_brew_taps(pkg_mngr_dict['taps']['macOS'])
```

To resolve this, a conditional check for the OS type is added before installing taps

```python
if pkg_mngr == 'brew':
    if 'Darwin' in OS:
        # this installs macOS brew taps
        install_brew_taps(pkg_mngr_dict['taps']['macOS'])
```
