### PR TITLE
Fixes for setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -138,8 +138,7 @@ py_return_code=$?
 if [ $py_return_code -ne 0 ]; then
     if [ "$OS" == "Darwin" ]; then
 	echo "Installing Python3.11 via brew..."
-        brew install python@3.11 pipx
-	pipx ensurepath
+        brew install python@3.11
     	echo -e "\033[92mPython3.11 installed :3 \033[00m"
     else
 	echo "Installing Python3.11 via apt..."
@@ -159,15 +158,21 @@ else
         DEBIAN_FRONTEND=noninteractive && \
 	sudo apt-get update && \
 	sudo apt-get install -y python3-pip python3-venv
+	curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
 	echo -e "\033[92mPip3.11 installed :3 \033[00m"
     fi
+
+    echo 'export PATH="$PATH:/home/friend/.local/bin/"' >> ~/.bashrc
+    . ~/.bashrc
 fi
 
 if [[ "$OS" == *"Linux"* ]]; then
     echo ""
     echo "We will remove /usr/lib/python3.*/EXTERNALLY-MANAGED until Debian Bookworm decides on a better way forward with virtual envs."
     echo "See: https://salsa.debian.org/cpython-team/python3/-/blob/master/debian/README.venv"
-    sudo rm /usr/lib/python3.*/EXTERNALLY-MANAGED
+    if [ -e /usr/lib/python3.*/EXTERNALLY-MANAGED ]; then
+         sudo rm /usr/lib/python3.*/EXTERNALLY-MANAGED
+    fi
 fi
 
 echo -e "--------------------------\033[94m Installing OnBoardMe :D \033[00m -------------------------"

--- a/setup.sh
+++ b/setup.sh
@@ -144,8 +144,8 @@ if [ $py_return_code -ne 0 ]; then
 	echo "Installing Python3.11 via apt..."
         DEBIAN_FRONTEND=noninteractive && \ 
 	sudo apt-get install software-properties-common -y && \
-        sudo add-apt-repository ppa:deadsnakes/ppa
-        sudo apt install python3.11
+        sudo add-apt-repository ppa:deadsnakes/ppa && \
+        sudo apt install -y python3.11 && \
         curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
 	echo -e "\033[92mPython3.11 installed :3 \033[00m"
     fi
@@ -157,7 +157,7 @@ else
         echo -e "\033[92mInstalling pip via apt... \033[00m"
         DEBIAN_FRONTEND=noninteractive && \
 	sudo apt-get update && \
-	sudo apt-get install -y python3-pip python3-venv
+	sudo apt-get install -y python3-pip python3-venv && \
 	curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
 	echo -e "\033[92mPip3.11 installed :3 \033[00m"
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -161,7 +161,7 @@ else
 	sudo apt-get install -y python3-pip python3-venv
 	echo -e "\033[92mPip3.11 installed :3 \033[00m"
     fi
-f
+fi
 
 if [[ "$OS" == *"Linux"* ]]; then
     echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -143,10 +143,12 @@ if [ $py_return_code -ne 0 ]; then
     else
 	echo "Installing Python3.11 via apt..."
         DEBIAN_FRONTEND=noninteractive && \ 
-	sudo apt-get install software-properties-common -y && \
-        sudo add-apt-repository ppa:deadsnakes/ppa && \
+	sudo apt-get install -y software-properties-common && \
+        sudo add-apt-repository -y ppa:deadsnakes/ppa && \
         sudo apt install -y python3.11 && \
         curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
+	echo 'export PATH="$PATH:/home/friend/.local/bin/"' >> ~/.bashrc
+    	. ~/.bashrc
 	echo -e "\033[92mPython3.11 installed :3 \033[00m"
     fi
 else
@@ -159,11 +161,11 @@ else
 	sudo apt-get update && \
 	sudo apt-get install -y python3-pip python3-venv && \
 	curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
+	echo 'export PATH="$PATH:/home/friend/.local/bin/"' >> ~/.bashrc
+    	. ~/.bashrc
 	echo -e "\033[92mPip3.11 installed :3 \033[00m"
     fi
 
-    echo 'export PATH="$PATH:/home/friend/.local/bin/"' >> ~/.bashrc
-    . ~/.bashrc
 fi
 
 if [[ "$OS" == *"Linux"* ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -131,6 +131,16 @@ fi
 
 
 echo -e "--------------------------\033[94m Checking for Python3 and pip3\033[00m -------------------------"
+
+if [[ "$OS" == *"Linux"* ]]; then
+    echo ""
+    echo "We will remove /usr/lib/python3.*/EXTERNALLY-MANAGED until Debian Bookworm decides on a better way forward with virtual envs."
+    echo "See: https://salsa.debian.org/cpython-team/python3/-/blob/master/debian/README.venv"
+    if [ -e /usr/lib/python3.*/EXTERNALLY-MANAGED ]; then
+         sudo rm /usr/lib/python3.*/EXTERNALLY-MANAGED
+    fi
+fi
+
 # check to make sure we have python3 and pip3 installed
 which python3.11 > /dev/null
 py_return_code=$?
@@ -164,16 +174,6 @@ else
 	echo 'export PATH="$PATH:/home/friend/.local/bin/"' >> ~/.bashrc
     	. ~/.bashrc
 	echo -e "\033[92mPip3.11 installed :3 \033[00m"
-    fi
-
-fi
-
-if [[ "$OS" == *"Linux"* ]]; then
-    echo ""
-    echo "We will remove /usr/lib/python3.*/EXTERNALLY-MANAGED until Debian Bookworm decides on a better way forward with virtual envs."
-    echo "See: https://salsa.debian.org/cpython-team/python3/-/blob/master/debian/README.venv"
-    if [ -e /usr/lib/python3.*/EXTERNALLY-MANAGED ]; then
-         sudo rm /usr/lib/python3.*/EXTERNALLY-MANAGED
     fi
 fi
 


### PR DESCRIPTION
- fixes a missing character error for open if-fi pair
- fixes pip3.11 install being skipped when python3.11 is not installed by default
- added flags and command chaining to present being prompted for input during installation of python3.11 on systems where it is not included by default
- resolved issue with pip3.11 being installed but not present on $PATH at the proper time in execution order

Tested on latest daily Debain12 bookworm and Ubuntu 22.04LTS

Debian="https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-amd64-daily.qcow2"

Ubuntu="https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"