### PR TITLE
Fix docker arm scripts

### DIFF
--- a/.github/workflows/docker-push-daily.yml
+++ b/.github/workflows/docker-push-daily.yml
@@ -70,7 +70,7 @@ jobs:
           # build from docker/ directory
           context: docker
           platforms: linux/amd64
-          build-args: "RUN_MODE=true"
+          build-args: "DEFAULT=true"
           tags: |
             jessebot/onboardme:latest
             jessebot/onboardme:debian12
@@ -83,7 +83,6 @@ jobs:
           context: docker
           platforms: linux/amd64
           build-args: |
-            "RUN_MODE=true"
             "DEFAULT=true"
             "DEVOPS=true"
           tags: |
@@ -98,7 +97,6 @@ jobs:
           context: docker
           platforms: linux/amd64
           build-args: |
-            "RUN_MODE=true"
             "DEFAULT=true"
             "DEVOPS=true"
             "MAIL=true"
@@ -148,7 +146,7 @@ jobs:
           # use special Dockerfile for arm builds
           file: docker/Dockerfile.arm
           platforms: linux/arm64
-          build-args: "RUN_MODE=default"
+          build-args: "DEFAULT=true"
           tags: |
             jessebot/onboardme:latest-arm
             jessebot/onboardme:debian12-arm
@@ -163,7 +161,6 @@ jobs:
           file: docker/Dockerfile.arm
           platforms: linux/arm64
           build-args: |
-            "RUN_MODE=true"
             "DEFAULT=true"
             "DEVOPS=true"
           tags: |
@@ -180,7 +177,6 @@ jobs:
           file: docker/Dockerfile.arm
           platforms: linux/arm64
           build-args: |
-            "RUN_MODE=true"
             "DEFAULT=true"
             "DEVOPS=true"
             "MAIL=true"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,7 @@
 # onbaordme Debian Bookworm image - linux/amd64 only
 FROM debian:bookworm-slim
 
-# "true"    - runs: onboardme --no_upgrade
-# ""        - will install onboardme, but won't run onboardme
-ARG RUN_MODE=""
-# extra package groups you can enable
+# package groups you can enable
 ARG DEFAULT=""
 ARG DATA_SCIENCE=""
 ARG DEVOPS=""
@@ -78,7 +75,7 @@ COPY --chown=friend:friend ./config.conf ./run_onboardme.sh /tmp/
 RUN pip install --user onboardme --break-system-packages && \
     onboardme --version
 
-RUN if [ -n "$RUN_MODE" ]; then bash /tmp/run_onboardme.sh; fi
+RUN if [ -n "$DEFAULT" ]; then bash /tmp/run_onboardme.sh; fi
 
 RUN brew cleanup && \
     sudo apt-get clean && \

--- a/docker/Dockerfile.arm
+++ b/docker/Dockerfile.arm
@@ -1,10 +1,7 @@
 # onbaordme Debian Bookworm image - linux/arm64 only
 FROM debian:bookworm-slim
 
-# "true"    - runs: onboardme --no_upgrade
-# ""        - will install onboardme, but won't run onboardme
-ARG RUN_MODE=""
-# extra package groups you can enable
+# package groups you can enable
 ARG DEFAULT=""
 ARG DATA_SCIENCE=""
 ARG DEVOPS=""
@@ -70,7 +67,7 @@ COPY --chown=friend:friend ./arm_config/default-onboardme-install.sh /tmp/
 COPY --chown=friend:friend ./arm_config/devops-onboardme-install.sh /tmp/
 COPY --chown=friend:friend ./arm_config/music-onboardme-install.sh /tmp/
 
-RUN if [ -n "$RUN_MODE" ]; then bash /tmp/default-onboardme-install.sh; fi
+RUN if [ -n "$DEFAULT" ]; then bash /tmp/default-onboardme-install.sh; fi
 
 RUN sudo apt-get clean && \
     sudo pip cache purge && \

--- a/docker/Dockerfile.rust-builder
+++ b/docker/Dockerfile.rust-builder
@@ -1,0 +1,24 @@
+# this file is just a rust builder for ARM
+# note the platform is arm64
+FROM --platform=linux/arm64/v8 rust:slim-bookworm
+
+# this could be any rust repo
+ENV RUST_REPO="https://github.com/Spotifyd/spotifyd.git"
+# all the prereq packages you need to install, separated by spaces
+ENV APT_PKGS="libasound2-dev libssl-dev libpulse-dev libdbus-1-dev"
+
+# install prereqs for spotifyd and install cargo-deb for making debian packages
+RUN apt update && \
+    apt install -y --no-install-recommends git $APT_PKGS && \
+    cargo install cargo-deb
+
+RUN echo "made it here"
+
+# # clone the rust repo
+RUN git clone $RUST_REPO /app
+
+WORKDIR /app
+
+# build the rust package and copy it to /
+RUN cargo deb && \
+    cp ./target/debian/*.deb /

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,8 +16,11 @@
 - `run_onboardme.sh` is for running onboardme with package groups based on docker env vars
 
 ```bash
-# this builds the DEFAULT onboardme image with onboardme and prereqs but doesn't run onboardme
+# this builds the onboardme image with prereqs but doesn't run onboardme
 docker build --platform=linux/amd64 -t onboardme:dev-prereqs .
+
+# this builds the onboardme image with the DEFAULT install for onboardme
+docker build --platform=linux/amd64 --build-arg='DEFAULT=True' -t onboardme:dev-prereqs .
 ```
 
 ## Only ARM 64 (aarch64)
@@ -32,13 +35,13 @@ To build this image run:
 docker build --platform=linux/arm64 -t onboardme:dev-prereqs-arm -f Dockerfile.arm .
 
 # this builds the onboardme image with the DEFAULT install for onboardme
-docker build --platform=linux/arm64 --build-arg='RUN_MODE=default' --build-arg='DEFAULT=True' -t onboardme:dev-arm -f Dockerfile.arm .
+docker build --platform=linux/arm64 --build-arg='DEFAULT=True' -t onboardme:dev-arm -f Dockerfile.arm .
 
 # this builds the onboardme image with the devops install for onboardme
-docker build --platform=linux/arm64 --build-arg='RUN_MODE=default' --build-arg='DEFAULT=True' --build-arg='DEVOPS=True' -t onboardme:dev-devops-arm -f Dockerfile.arm .
+docker build --platform=linux/arm64 --build-arg='DEFAULT=True' --build-arg='DEVOPS=True' -t onboardme:dev-devops-arm -f Dockerfile.arm .
 
 # this builds the onboardme image with the full-tui install for onboardme
-docker build --platform=linux/arm64 --build-arg='RUN_MODE=default' --build-arg='DEFAULT=True' --build-arg='DEVOPS=True' --build-arg='MUSIC=True' -t onboardme:dev-full-tui-arm -f Dockerfile.arm .
+docker build --platform=linux/arm64 --build-arg='DEFAULT=True' --build-arg='DEVOPS=True' --build-arg='MUSIC=True' -t onboardme:dev-full-tui-arm -f Dockerfile.arm .
 ```
 
 ## Used in arm64 (aarch64) _and_ amd64

--- a/docker/README.md
+++ b/docker/README.md
@@ -32,13 +32,13 @@ To build this image run:
 docker build --platform=linux/arm64 -t onboardme:dev-prereqs-arm -f Dockerfile.arm .
 
 # this builds the onboardme image with the DEFAULT install for onboardme
-docker build --platform=linux/arm64 --build-arg='DEFAULT=True' -t onboardme:dev-arm -f Dockerfile.arm .
+docker build --platform=linux/arm64 --build-arg='RUN_MODE=default' --build-arg='DEFAULT=True' -t onboardme:dev-arm -f Dockerfile.arm .
 
 # this builds the onboardme image with the devops install for onboardme
-docker build --platform=linux/arm64 --build-arg='DEFAULT=True' --build-arg='DEVOPS=True' -t onboardme:dev-devops-arm -f Dockerfile.arm .
+docker build --platform=linux/arm64 --build-arg='RUN_MODE=default' --build-arg='DEFAULT=True' --build-arg='DEVOPS=True' -t onboardme:dev-devops-arm -f Dockerfile.arm .
 
 # this builds the onboardme image with the full-tui install for onboardme
-docker build --platform=linux/arm64 --build-arg='DEFAULT=True' --build-arg='DEVOPS=True' --build-arg='MUSIC=True' -t onboardme:dev-full-tui-arm -f Dockerfile.arm .
+docker build --platform=linux/arm64 --build-arg='RUN_MODE=default' --build-arg='DEFAULT=True' --build-arg='DEVOPS=True' --build-arg='MUSIC=True' -t onboardme:dev-full-tui-arm -f Dockerfile.arm .
 ```
 
 ## Used in arm64 (aarch64) _and_ amd64

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
 
 ```
 ├──  arm_config
-│   ├──  default-onboardme-install.sh
+│   ├──  DEFAULT-onboardme-install.sh
 │   ├──  devops-onboardme-install.sh
 │   └──  music-onboardme-install.sh
 ├── ⚙️ config.conf
@@ -16,7 +16,8 @@
 - `run_onboardme.sh` is for running onboardme with package groups based on docker env vars
 
 ```bash
-docker build --platform=linux/arm64 -t onboardme:dev .
+# this builds the DEFAULT onboardme image with onboardme and prereqs but doesn't run onboardme
+docker build --platform=linux/amd64 -t onboardme:dev-prereqs .
 ```
 
 ## Only ARM 64 (aarch64)
@@ -27,7 +28,17 @@ Homebrew on Linux [does not support ARM64 (aarch64)](https://docs.brew.sh/Homebr
 To build this image run:
 
 ```bash
-docker build --platform=linux/arm64 -t onboardme:dev-arm -f Dockerfile.arm .
+# this builds the DEFAULT onboardme image with onboardme and prereqs but doesn't run onboardme
+docker build --platform=linux/arm64 -t onboardme:dev-prereqs-arm -f Dockerfile.arm .
+
+# this builds the onboardme image with the DEFAULT install for onboardme
+docker build --platform=linux/arm64 --build-arg='DEFAULT=True' -t onboardme:dev-arm -f Dockerfile.arm .
+
+# this builds the onboardme image with the devops install for onboardme
+docker build --platform=linux/arm64 --build-arg='DEFAULT=True' --build-arg='DEVOPS=True' -t onboardme:dev-devops-arm -f Dockerfile.arm .
+
+# this builds the onboardme image with the full-tui install for onboardme
+docker build --platform=linux/arm64 --build-arg='DEFAULT=True' --build-arg='DEVOPS=True' --build-arg='MUSIC=True' -t onboardme:dev-full-tui-arm -f Dockerfile.arm .
 ```
 
 ## Used in arm64 (aarch64) _and_ amd64

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,14 +11,24 @@
 └──  run_onboardme.sh
 ```
 
-## Used in arm64 (aarch64) and amd64
-`config.conf` is a special fastfetch config used for both docker images
-
 ## Only x86_64 (amd64)
 - `Dockerfile` is for linux/amd64
 - `run_onboardme.sh` is for running onboardme with package groups based on docker env vars
+
+```bash
+docker build --platform=linux/arm64 -t onboardme:dev .
+```
 
 ## Only ARM 64 (aarch64)
 Homebrew on Linux [does not support ARM64 (aarch64)](https://docs.brew.sh/Homebrew-on-Linux#arm-unsupported), so we have special images for that.
 - `Dockerfile.arm` is for linux/arm64 and linux/aarch64
 - `arm_config` is a directory of files just for arm builds to download binaries and compile from source if there's no package manager package.
+
+To build this image run:
+
+```bash
+docker build --platform=linux/arm64 -t onboardme:dev-arm -f Dockerfile.arm .
+```
+
+## Used in arm64 (aarch64) _and_ amd64
+`config.conf` is a special fastfetch config used for both docker images

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,14 +1,15 @@
 # Files for building onboardme docker containers
 
-```
+```bash
 ├──  arm_config
-│   ├──  DEFAULT-onboardme-install.sh
-│   ├──  devops-onboardme-install.sh
-│   └──  music-onboardme-install.sh
+│   ├──   default-onboardme-install.sh
+│   ├──   devops-onboardme-install.sh
+│   └──   music-onboardme-install.sh
 ├── ⚙️ config.conf
 ├── 🐳 Dockerfile
 ├── 🐳 Dockerfile.arm
-└──  run_onboardme.sh
+├── 🐳 Dockerfile.rust-builder
+└──   run_onboardme.sh
 ```
 
 ## Only x86_64 (amd64)
@@ -46,3 +47,13 @@ docker build --platform=linux/arm64 --build-arg='DEFAULT=True' --build-arg='DEVO
 
 ## Used in arm64 (aarch64) _and_ amd64
 `config.conf` is a special fastfetch config used for both docker images
+
+## Building rust packages
+Several apps written in rust don't have Debian packages, so we create them using `Dockerfile.rust-builder`:
+```bash
+# build the docker image, but you could also grab the code from this file and do a multistage build
+docker buildx build --platform=linux/arm64 -t rustbuilder:spotifyd-dev -f Dockerfile.rust-builder .
+
+# this creates the image and copies the deb to your current directory
+docker cp $(docker create --name rustemp rustbuilder:spotifyd-dev):/spotifyd_0.3.5_arm64.deb . && docker rm rustemp
+```

--- a/docker/arm_config/default-onboardme-install.sh
+++ b/docker/arm_config/default-onboardme-install.sh
@@ -1,8 +1,3 @@
-echo "setting up default onbaordme config"
-mkdir -p $XDG_CONFIG_HOME/onboardme
-mv /tmp/packages.yml $XDG_CONFIG_HOME/onboardme/
-mv /tmp/config.yml $XDG_CONFIG_HOME/onboardme/
-
 echo ""
 echo "compiling neovim from source, before we run onboardme"
 echo "ref: https://github.com/neovim/neovim/wiki/Building-Neovim#build-prerequisites"

--- a/docker/arm_config/devops-onboardme-install.sh
+++ b/docker/arm_config/devops-onboardme-install.sh
@@ -1,6 +1,3 @@
-# install gpg so that we can verify gpg keys of external apt repos
-sudo apt install --no-install-recommends -y gpg
-
 # install gpg-tui, a TUI for gpg keys, for the lazy, like me: has to be compiled from source
 # maybe use 🤷:
 # https://github.com/orhun/gpg-tui/releases/download/v0.9.6/gpg-tui-0.9.6-x86_64-unknown-linux-gnu.tar.gz
@@ -62,6 +59,8 @@ sudo install -m 555 argocd-linux-arm64 /usr/local/bin/argocd
 rm argocd-linux-arm64
 
 ## tfenv: https://github.com/tfutils/tfenv#manual
+# TODO: maybe move this $XDG_DATA_HOME/tfenv and
+#       add $XDG_DATA_HOME/tfenv to the path?
 git clone --depth=1 https://github.com/tfutils/tfenv.git ~/.tfenv
 echo 'export PATH="$HOME/.tfenv/bin:$PATH"' >> ~/.bashrc
 
@@ -72,9 +71,4 @@ curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/instal
 curl -LO https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-$(uname)-amd64.tar.gz /tmp/
 tar -xzf terraform-docs-v0.16.0-$(uname)-amd64.tar.gz
 chmod +x terraform-docs
-mv terraform-docs /usr/local/terraform-docs
-
-## rustup: https://forge.rust-lang.org/infra/other-installation-methods.html
-curl -LO /tmp/ https://static.rust-lang.org/dist/rust-1.69.0-aarch64-unknown-linux-gnu.tar.gz
-tar xvf /tmp/rust-1.69.0-aarch64-unknown-linux-gnu.tar.gz
-rustup update
+mv terraform-docs ~/.local/bin/terraform-docs

--- a/docker/arm_config/devops-onboardme-install.sh
+++ b/docker/arm_config/devops-onboardme-install.sh
@@ -1,15 +1,17 @@
+# install gpg so that we can verify gpg keys of external apt repos
+sudo apt install --no-install-recommends -y gpg
+
 # install gpg-tui, a TUI for gpg keys, for the lazy, like me: has to be compiled from source
 # maybe use 🤷:
 # https://github.com/orhun/gpg-tui/releases/download/v0.9.6/gpg-tui-0.9.6-x86_64-unknown-linux-gnu.tar.gz
 
 ## install gh - github's CLI
 ## ref: https://github.com/cli/cli/blob/trunk/docs/install_linux.md
-# type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
-# curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-# sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-# echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-# sudo apt update
-# sudo apt install -y gh
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+sudo apt update
+sudo apt install -y gh
 
 ## install glab - gitlab's cli
 ## ref: https://gitlab.com/gitlab-org/cli/-/blob/main/docs/installation_options.md#mpr-debianubuntu
@@ -67,8 +69,8 @@ echo 'export PATH="$HOME/.tfenv/bin:$PATH"' >> ~/.bashrc
 curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
 
 ## terraform-docs: https://github.com/terraform-docs/terraform-docs/
-curl -Lo /tmp/terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-$(uname)-amd64.tar.gz
-tar -xzf terraform-docs.tar.gz
+curl -LO https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-$(uname)-amd64.tar.gz /tmp/
+tar -xzf terraform-docs-v0.16.0-$(uname)-amd64.tar.gz
 chmod +x terraform-docs
 mv terraform-docs /usr/local/terraform-docs
 

--- a/docker/arm_config/music-onboardme-install.sh
+++ b/docker/arm_config/music-onboardme-install.sh
@@ -1,3 +1,10 @@
+## rustup: https://forge.rust-lang.org/infra/other-installation-methods.html
+curl -LO https://static.rust-lang.org/dist/rust-1.69.0-aarch64-unknown-linux-gnu.tar.gz /tmp/
+tar xvf /tmp/rust-1.69.0-aarch64-unknown-linux-gnu.tar.gz
+cd rust-1.69.0-aarch64-unknown-linux-gnu/
+rustup update
+cd ..
+
 ## install spotifyd
 # for this we need cargo already via rustup, which is in the devops file
 sudo apt install -y libasound2-dev libssl-dev

--- a/docker/arm_config/music-onboardme-install.sh
+++ b/docker/arm_config/music-onboardme-install.sh
@@ -12,9 +12,6 @@ git clone https://github.com/Spotifyd/spotifyd.git
 cd spotifyd
 cargo build --release
 
-## install spotify-tui, for controlling spotify
-cargo install --git https://github.com/spotify-tui/spotify-tui
-
 ## add somafm for free internet radio out of SF
 # ref: https://github.com/cuschk/somafm
 npm install --global somafm


### PR DESCRIPTION
There were some issues with some stuff not getting installed, like in #211 (issues with k9s and helm).

Removes `RUN_MODE` build arg from Dockerfiles. Now we default just always installing onboardme and we only run onboardme if you pass in `DEFAULT=true` and/or `DEVOPS=true` and/or `MUSIC=true`.

Music on docker using ARM AKA `jessebot/onboardme:arm-full-tui` is still in need of actually using the rust build container to build the .deb. I left instructions in `docker/README.md` if you want to try it yourself.

Fixes `terraform-docs` and `helm` install and adds `gpg` as a devops dependency.