### PR TITLE
allow and prefer pipx via brew, allow pip3.11

### DIFF
--- a/onboardme/constants.py
+++ b/onboardme/constants.py
@@ -32,7 +32,7 @@ if OS[0] == 'Darwin':
     STEPS.append('sudo_setup')
 
 # package manager config is different per OS
-PKG_MNGRS = ['brew','pip3.12']
+PKG_MNGRS = ['brew','pip3.12','pip3.11','pipx']
 if OS[0] == 'Linux':
     PKG_MNGRS.extend(['apt','snap','flatpak'])
 

--- a/onboardme/env_config.py
+++ b/onboardme/env_config.py
@@ -12,7 +12,7 @@ from .constants import OS, USR_CONFIG_FILE, DEFAULT_PKG_GROUPS, HOME_DIR
 from .console_logging import print_panel
 
 
-def check_os_support():
+def check_os_support() -> None:
     """
     verify we're on a supported OS and ask to quit if not.
     """
@@ -33,7 +33,7 @@ def check_os_support():
                     "[cornflower_blue]Compatibility Check")
 
 
-def process_steps(steps: list, firewall=False, browser=False) -> list:
+def process_steps(steps: list, firewall: bool = False, browser: bool = False) -> list:
     """
     process which steps to run for which OS, which steps the user passed in,
     and then make sure dependent steps are always run.
@@ -70,9 +70,9 @@ def sort_pkgmngrs(package_managers_list: list) -> list:
     e.g. apt installs snap and flatpak, so niether can be run until apt is run
 
     Takes list of package manager str and reorders them be (if they exist):
-       ['brew', 'pip3.12', 'pip3.11', 'apt', 'snap', 'flatpak']
+       ['brew', 'pip3.12', 'pip3.11', 'pipx', 'apt', 'snap', 'flatpak']
     """
-    pkg_mngr_default_order = ['brew', 'pip3.12', 'pip3.11', 'apt', 'snap', 'flatpak']
+    pkg_mngr_default_order = ['brew', 'pip3.12', 'pip3.11', 'pipx', 'apt', 'snap', 'flatpak']
 
     # Rearrange list by other list order Using list comprehension
     return [ele for ele in pkg_mngr_default_order if ele in package_managers_list]
@@ -87,7 +87,7 @@ def fill_in_defaults(defaults: dict, user_config: dict,
     for key, value in user_config.items():
         # we have to iterate through the entire config file, and who knows how
         # many levels there are, so we use recursion of this function
-        if type(value) is dict:
+        if isinstance(value, dict):
             result_config = fill_in_defaults(defaults[key], user_config[key],
                                              always_prefer_default)
             user_config[key] = result_config
@@ -116,7 +116,7 @@ def process_configs(overwrite: bool,
     """
     if remote_host:
         firewall = True
-        if type(remote_host) is str:
+        if isinstance(remote_host, str):
             remote_host = [remote_host]
 
     if "~" in git_config_dir:

--- a/onboardme/pkg_management.py
+++ b/onboardme/pkg_management.py
@@ -75,10 +75,10 @@ def run_preinstall_cmds(cmd_list: list,
             sub_header(f"[b]{pre_cmd.title()}[/b] completed.")
 
 
-def run_pkg_mngrs(pkg_mngrs: list, pkg_groups=[], no_upgrade=bool) -> None:
+def run_pkg_mngrs(pkg_mngrs: list, pkg_groups: list = [], no_upgrade: bool = False) -> None:
     """
-    Installs brew and pip3.12 packages. Also apt, snap, and flatpak on Linux.
-    Takes optional variables:
+    Installs brew, pip3.12/pip3.11, and pipx packages on both Debian/Ubuntu/macOS
+    Also apt, snap, and flatpak on Linux. Takes optional variables:
       - pkg_groups: list of optional package groups
       - pkg_mngrs: list of package managers to run
     Returns True
@@ -99,7 +99,7 @@ def run_pkg_mngrs(pkg_mngrs: list, pkg_groups=[], no_upgrade=bool) -> None:
         if pkg_mngr == 'brew':
             if 'Darwin' in OS:
                 if 'default' in pkg_groups:
-                    if type(pkg_groups) is tuple:
+                    if isinstance(pkg_groups, tuple):
                         pkg_groups = list(pkg_groups)
                     pkg_groups.append("macOS")
 
@@ -120,6 +120,19 @@ def run_pkg_mngrs(pkg_mngrs: list, pkg_groups=[], no_upgrade=bool) -> None:
                 log.warn("snap is either not installed, or you need to log out"
                          "and back in (or reboot) for it to be available. "
                          "https://snapcraft.io/docs/installing-snap-on-debian")
+                # continues onto the next package manager
+                continue
+
+            if pkg_mngr == 'flatpak' and not shutil.which('flatpak'):
+                log.warn("flatpak is either not installed, or you need to log out"
+                         "and back in (or reboot) for it to be available. "
+                         "https://flatpak.org/setup/")
+                # continues onto the next package manager
+                continue
+
+            if pkg_mngr == 'pip3.11' and not shutil.which('pip3.11'):
+                log.info("pip3.11 is either not installed, or you need to log out"
+                         "and back in for it to be available.")
                 # continues onto the next package manager
                 continue
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "onboardme"
-version       = "1.8.0"
+version       = "1.9.0"
 description   = "Install dot files and packages, including a base mode with sensible defaults to run on most computers running Debian based distros or macOS."
 authors       = [
     "Jesse Hitch <jessebot@linux.com>",


### PR DESCRIPTION
also cleans up some linting stuff like using `isinstance(variable, type)` instead of direct type comparison, whitespace, and there's an accompanying push to the dot files that also adds pipx and in particular, it installs onboardme and smol-k8s-lab with pipx